### PR TITLE
fix: union type naming for mongo_fields having inner mongo_field

### DIFF
--- a/graphene_mongo/converter.py
+++ b/graphene_mongo/converter.py
@@ -350,10 +350,20 @@ def convert_field_to_union(field, registry=None, executor: ExecutorEnum = Execut
     if len(_types) == 0:
         return None
 
-    name = (
-        to_camel_case("{}_{}".format(field._owner_document.__name__, field.db_field)) + "UnionType"
-        if ExecutorEnum.SYNC
-        else "AsyncUnionType"
+    field_name = field.db_field
+    if field_name is None:
+        # Get db_field name from parent mongo_field
+        for db_field_name, _mongo_parent_field in field.owner_document._fields.items():
+            if hasattr(_mongo_parent_field, "field") and _mongo_parent_field.field == field:
+                field_name = db_field_name
+                break
+
+    name = to_camel_case(
+        "{}_{}_{}".format(
+            field._owner_document.__name__,
+            field_name,
+            "union_type" if executor == ExecutorEnum.SYNC else "async_union_type",
+        )
     )
     Meta = type("Meta", (object,), {"types": tuple(_types)})
     _union = type(name, (graphene.Union,), {"Meta": Meta})


### PR DESCRIPTION
eg:

`field_1 = ListField(GenericLazyReferenceField(choices=[X1,X2]))` generates type `ModelNoneUnionType`

This fix will make it `ModelField1UnionType`